### PR TITLE
Enable passing profile to certificate request

### DIFF
--- a/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
+++ b/lib/puppet/provider/certmonger_certificate/certmonger_certificate.rb
@@ -184,6 +184,10 @@ Puppet::Type.type(:certmonger_certificate).provide :certmonger_certificate do
     else
       raise ArgumentError, "An empty value for the keyfile is not allowed"
     end
+    if resource[:profile]
+      request_args << '-T'
+      request_args << resource[:profile]
+    end
     return request_args
   end
 

--- a/lib/puppet/type/certmonger_certificate.rb
+++ b/lib/puppet/type/certmonger_certificate.rb
@@ -147,6 +147,10 @@ Puppet::Type.newtype(:certmonger_certificate) do
           "the request.")
   end
 
+  newparam(:profile) do
+    desc "ask the CA to process the request using the named profile."
+  end
+
   newparam(:force_resubmit) do
     desc "If the request is found, force a resubmit operation."
     defaultto :false

--- a/spec/unit/puppet/type/certmonger_certificate_spec.rb
+++ b/spec/unit/puppet/type/certmonger_certificate_spec.rb
@@ -341,5 +341,19 @@ describe Puppet::Type.type(:certmonger_certificate) do
         }.to_not raise_error
       end
     end
+
+    describe :profile do
+      it 'should have a profile parameter' do
+        expect(
+          Puppet::Type.type(:certmonger_certificate).attrtype(:profile)
+        ).to eq(:param)
+      end
+      it 'should validate and pass if valid value' do
+        expect {
+          Puppet::Type.type(:certmonger_certificate).new(
+            :name => name, :ensure => :present, :ca_error => 'some_value')
+        }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This enables passing the profile as a parameter to the custom
resource. But currently doesn't fetch the profile that was used for a
certificate as I didn't figure out how to do so.
